### PR TITLE
Containerized travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ install:
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
      cabal install --only-dependencies --enable-tests --enable-benchmarks;
-     # if [ "$GHCVER" = "7.10.1" ]; then cabal install Cabal-1.22.4.0; fi; # enable this if we switch to a custom Setup.hs
    fi
 
 # snapshot package-db on cache miss
@@ -82,7 +81,6 @@ install:
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
- # - if [ -f configure.ac ]; then autoreconf -i; fi # enable this if we need autoconf
  - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,6 @@ before_install:
  - export RACKET_DIR=/home/travis/racket
  - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
 
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
-
  # install Racket
  - git clone https://github.com/greghendershott/travis-racket.git
  - cat travis-racket/install-racket.sh | bash # pipe to bash not sh!

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
  - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
 
  # install Racket if it isn't already installed
- - if [ ! -d $HOME/racket ]; then
+ - if [ ! -f $RACKET_DIR/bin/raco ]; then
      git clone https://github.com/greghendershott/travis-racket.git;
      cat travis-racket/install-racket.sh | bash;
    fi
@@ -51,8 +51,7 @@ install:
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
 
  # install HerbiePlugin
- - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
-   then
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ]; then
      zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
           $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
    fi
@@ -62,8 +61,7 @@ install:
  - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
 
 # check whether current requested install-plan matches cached package-db snapshot
- - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
-   then
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt; then
      echo "cabal build-cache HIT";
      rm -rfv .ghc;
      cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
@@ -77,12 +75,11 @@ install:
    fi
 
 # snapshot package-db on cache miss
- - if [ ! -d $HOME/.cabsnap ];
-   then
-      echo "snapshotting package-db to build-cache";
-      mkdir $HOME/.cabsnap;
-      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
-      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+ - if [ ! -d $HOME/.cabsnap ]; then
+     echo "snapshotting package-db to build-cache";
+     mkdir $HOME/.cabsnap;
+     cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+     cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
    fi
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ before_install:
  - unset CC
  - export HAPPYVER=1.19.5
  - export ALEXVER=3.1.4
- - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$PATH
+ - export RACKET_DIR=/home/travis/racket
+ - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
 
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,33 @@
 # NB: don't set `language: haskell` here
+language: c
+sudo: false
 
-# The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
-env:
- - CABALVER=1.22 GHCVER=7.10.1 RACKET_VERSION=6.1
- - CABALVER=1.22 GHCVER=7.10.2 RACKET_VERSION=6.1
- # - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
+cache:
+  directories:
+    - $HOME/.cabsnap
+    - $HOME/.cabal/packages
+
+before_cache:
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
+  - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
+
+matrix:
+  include:
+    - env: CABALVER=1.22 GHCVER=7.10.1 RACKET_VERSION=6.1
+      compiler: ": #GHC 7.10.1"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.1,alex-3.1.4,happy-1.19.5,libblas-dev,liblapack-dev], sources: [hvr-ghc]}}
+    - env: CABALVER=1.22 GHCVER=7.10.2 RACKET_VERSION=6.1
+      compiler: ": #GHC 7.10.2"
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2,alex-3.1.4,happy-1.19.5,libblas-dev,liblapack-dev], sources: [hvr-ghc]}}
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
+ - unset CC
+ - export HAPPYVER=1.19.5
+ - export ALEXVER=3.1.4
+ - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$PATH
 
- - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
- - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
  - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
- - travis_retry sudo apt-get install libblas-dev liblapack-dev
 
  # install Racket
  - git clone https://github.com/greghendershott/travis-racket.git
@@ -23,20 +37,51 @@ install:
 
  # install herbie-exec
  - /usr/racket/bin/raco exe -o herbie-exec herbie/herbie/interface/inout.rkt
- - sudo mv herbie-exec /usr/local/bin
+ - mv herbie-exec /home/travis/.cabal/bin
 
  # manually download the expression database
  - wget https://github.com/mikeizbicki/HerbiePlugin/raw/master/data/Herbie.db
- - mkdir -p /home/travis/.cabal/share/x86_64-linux-ghc-7.10.1/HerbiePlugin-0.1.0.0/
- - cp Herbie.db /home/travis/.cabal/share/x86_64-linux-ghc-7.10.1/HerbiePlugin-0.1.0.0/
- - mkdir -p /home/travis/.cabal/share/x86_64-linux-ghc-7.10.2/HerbiePlugin-0.1.0.0/
- - cp Herbie.db /home/travis/.cabal/share/x86_64-linux-ghc-7.10.2/HerbiePlugin-0.1.0.0/
+ - mkdir -p /home/travis/.cabal/share/x86_64-linux-ghc-$GHCVER/HerbiePlugin-0.1.0.0/
+ - cp Herbie.db /home/travis/.cabal/share/x86_64-linux-ghc-$GHCVER/HerbiePlugin-0.1.0.0/
 
- # install HerbiePlugin
+ # display versions
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+
+ # install HerbiePlugin
+ - if [ -f $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz ];
+   then
+     zcat $HOME/.cabal/packages/hackage.haskell.org/00-index.tar.gz >
+          $HOME/.cabal/packages/hackage.haskell.org/00-index.tar;
+   fi
  - travis_retry cabal update
- - travis_retry cabal install -j4 --only-dependencies --enable-tests --enable-benchmarks
+ - "sed -i  's/^jobs:.*$/jobs: 2/' $HOME/.cabal/config"
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks --dry -v > installplan.txt
+ - sed -i -e '1,/^Resolving /d' installplan.txt; cat installplan.txt
+
+# check whether current requested install-plan matches cached package-db snapshot
+ - if diff -u installplan.txt $HOME/.cabsnap/installplan.txt;
+   then
+     echo "cabal build-cache HIT";
+     rm -rfv .ghc;
+     cp -a $HOME/.cabsnap/ghc $HOME/.ghc;
+     cp -a $HOME/.cabsnap/lib $HOME/.cabsnap/share $HOME/.cabsnap/bin $HOME/.cabal/;
+   else
+     echo "cabal build-cache MISS";
+     rm -rf $HOME/.cabsnap;
+     mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
+     cabal install --only-dependencies --enable-tests --enable-benchmarks;
+     if [ "$GHCVER" = "7.10.1" ]; then cabal install Cabal-1.22.4.0; fi;
+   fi
+
+# snapshot package-db on cache miss
+ - if [ ! -d $HOME/.cabsnap ];
+   then
+      echo "snapshotting package-db to build-cache";
+      mkdir $HOME/.cabsnap;
+      cp -a $HOME/.ghc $HOME/.cabsnap/ghc;
+      cp -a $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin installplan.txt $HOME/.cabsnap/;
+   fi
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
 install:
 
  # install herbie-exec
- - /usr/racket/bin/raco exe -o herbie-exec herbie/herbie/interface/inout.rkt
+ - raco exe -o herbie-exec herbie/herbie/interface/inout.rkt
  - mv herbie-exec /home/travis/.cabal/bin
 
  # manually download the expression database

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,8 @@ before_install:
  - export HAPPYVER=1.19.5
  - export ALEXVER=3.1.4
  - export RACKET_DIR=$HOME/racket/$RACKET_VERSION
- - mkdir -p $HOME/.cabal/bin
- - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
-
+ - export PATH=$HOME/bin:$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
+ - mkdir -p $HOME/bin
  # install Racket if it isn't already installed
  - if [ ! -d $RACKET_DIR ]; then
      git clone https://github.com/greghendershott/travis-racket.git;
@@ -37,10 +36,8 @@ before_install:
    fi
 
 install:
-
  # install herbie-exec
- - raco exe -o herbie-exec herbie/herbie/interface/inout.rkt
- - mv herbie-exec $HOME/.cabal/bin
+ - raco exe -o $HOME/bin/herbie-exec herbie/herbie/interface/inout.rkt
 
  # manually download the expression database
  - wget https://github.com/mikeizbicki/HerbiePlugin/raw/master/data/Herbie.db
@@ -72,7 +69,7 @@ install:
      rm -rf $HOME/.cabsnap;
      mkdir -p $HOME/.ghc $HOME/.cabal/lib $HOME/.cabal/share $HOME/.cabal/bin;
      cabal install --only-dependencies --enable-tests --enable-benchmarks;
-     if [ "$GHCVER" = "7.10.1" ]; then cabal install Cabal-1.22.4.0; fi;
+     # if [ "$GHCVER" = "7.10.1" ]; then cabal install Cabal-1.22.4.0; fi; # enable this if we switch to a custom Setup.hs
    fi
 
 # snapshot package-db on cache miss
@@ -85,7 +82,7 @@ install:
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
- - if [ -f configure.ac ]; then autoreconf -i; fi
+ # - if [ -f configure.ac ]; then autoreconf -i; fi # enable this if we need autoconf
  - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - $HOME/.cabsnap
     - $HOME/.cabal/packages
+    - $HOME/racket
 
 before_cache:
   - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
@@ -25,23 +26,25 @@ before_install:
  - unset CC
  - export HAPPYVER=1.19.5
  - export ALEXVER=3.1.4
- - export RACKET_DIR=/home/travis/racket
+ - export RACKET_DIR=$HOME/racket
  - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
 
- # install Racket
- - git clone https://github.com/greghendershott/travis-racket.git
- - cat travis-racket/install-racket.sh | bash # pipe to bash not sh!
+ # install Racket if it isn't already installed
+ - if [ ! -d $HOME/racket ]; then
+     git clone https://github.com/greghendershott/travis-racket.git;
+     cat travis-racket/install-racket.sh | bash;
+   fi
 
 install:
 
  # install herbie-exec
  - raco exe -o herbie-exec herbie/herbie/interface/inout.rkt
- - mv herbie-exec /home/travis/.cabal/bin
+ - mv herbie-exec $HOME/.cabal/bin
 
  # manually download the expression database
  - wget https://github.com/mikeizbicki/HerbiePlugin/raw/master/data/Herbie.db
- - mkdir -p /home/travis/.cabal/share/x86_64-linux-ghc-$GHCVER/HerbiePlugin-0.1.0.0/
- - cp Herbie.db /home/travis/.cabal/share/x86_64-linux-ghc-$GHCVER/HerbiePlugin-0.1.0.0/
+ - mkdir -p $HOME/.cabal/share/x86_64-linux-ghc-$GHCVER/HerbiePlugin-0.1.0.0/
+ - cp Herbie.db $HOME/.cabal/share/x86_64-linux-ghc-$GHCVER/HerbiePlugin-0.1.0.0/
 
  # display versions
  - cabal --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ before_install:
  - export HAPPYVER=1.19.5
  - export ALEXVER=3.1.4
  - export RACKET_DIR=$HOME/racket/$RACKET_VERSION
- - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
+ - mkdir -p $HOME/.cabal/bin
+ - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
 
  # install Racket if it isn't already installed
  - if [ ! -d $RACKET_DIR ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ before_install:
  - unset CC
  - export HAPPYVER=1.19.5
  - export ALEXVER=3.1.4
- - export RACKET_DIR=$HOME/racket
+ - export RACKET_DIR=$HOME/racket/$RACKET_VERSION
  - export PATH=~/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/happy/$HAPPYVER/bin:/opt/alex/$ALEXVER/bin:$RACKET_DIR/bin:$PATH
 
  # install Racket if it isn't already installed
- - if [ ! -f $RACKET_DIR/bin/raco ]; then
+ - if [ ! -d $RACKET_DIR ]; then
      git clone https://github.com/greghendershott/travis-racket.git;
      cat travis-racket/install-racket.sh | bash;
    fi


### PR DESCRIPTION
This switches the travis configuration to use containerized builds. `travis` devotes a lot more resources to these sorts of builds.

Along the way it picks up a number of improvements.
- Notably: this will cache the cabal install plan for dependencies. If the install plan is a hit then you'll get ~2.5 minute warm tests rather than 15 minute cold builds.
- I also set it up to cache the racket install.
- This now uses `jobs: 2` on travis, we get "1.5 cores" on a containerized VM, higher parallelism doesn't help.
